### PR TITLE
Saving and loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,5 @@ trmps/FashionMNISTDatasource/t10k-labels-idx1-ubyte.gz
 trmps/FashionMNISTDatasource/train-images-idx3-ubyte.gz
 
 trmps/FashionMNISTDatasource/train-labels-idx1-ubyte.gz
+
+trmps/MPSconfig

--- a/docs/source/api/mps/index.rst
+++ b/docs/source/api/mps/index.rst
@@ -103,6 +103,13 @@ __init__(d_feature, d_output, input_size, special_node_loc=None)
  *special_node_loc: int or None*
   The location of the "special node", i.e. the tensor which has the extra index  on it, which is where we obtain the prediction from. If loading in weights,  make sure that this location coincides with where the special node location  is in the weights you are loading in. If this value is set to None, then if  in the prepare method, no data_source is passed in, the special node location  is set automatically to be at the middle of the MPS. If this value is set to  None and a data_source is passed into the prepare method, then the special  node location is set to be the location where the weight from linear  regression was largest.
 
+from_file(path="MPSconfig")
+^^^^^^^^^
+ Initialises the MPS from the file at the path specified. If the file only contains the configuration of the MPS, and not the weights, the prepare method must be called after this before anything else can be done. More information on the file format can be found `here <https://github.com/TrMPS/MPS-MNIST/blob/master/Notes%20for%20developement.md>`_.
+
+ *path: string*
+  Specifies the path where the MPS configuration is stored.
+
 prepare(data_source=None, iterations=1000, learning_rate=0.05)
 ^^^^^^^^
  Prepares the MPS. Optionally uses linear regression, which can be thought of  as pre-training the network, and dramatically shortens the required training  time. This function must be called after the initialiser, before anything can  be done with the MPS.
@@ -210,4 +217,18 @@ f1score(f, labels, _confusion_matrix=None)
   The correct labels.
  *_confusion_matrix: a tensorflow Tensor of shape (d_output, d_output), or None*
   If the confusion matrix has already been evaluated elsewhere for other reasons, it can be passed in via this parameter, so that it does not have to be evaluated again. If passing in a confusion matrix, then f and labels are never used.
+
+Storing the MPS
+---------
+
+save(weights=None, path="MPSconfig")
+^^^^^^^^^
+ Saves the MPS configuration at the path given. If weights are given, then the weights will be stored as well. A new MPS can be created from the saved weights using from_file.
+
+ *weights: list of numpy arrays*
+  A list containing the trained weights of the MPS that are to be saved. If no value is passed in, only the configuration of the MPS will be stored.
+ *path: string*
+  Specifies the path where the MPS configuration is stored.
+
+
 

--- a/docs/source/api/optimizers/MPSTrainingParameters.rst
+++ b/docs/source/api/optimizers/MPSTrainingParameters.rst
@@ -11,7 +11,7 @@ __init__(rate_of_change=1000, initial_weights=None, _logging_enabled=False)
  *rate_of_change: float*
   The rate of change for the optimisation. Different values should be tried, as there is no 'right answer' that works for all situations, and depending on the data set, the same value can cause overshooting, or make the optimisation slower than it should be.
  *initial_weights: list*
-  The initial weights for the network, if it is desired to override the default values from mps.prepare(self, data_source, iterations = 1000)
+  The initial weights for the network, if it is desired to override the default values from MPS.prepare. Deprecated in favour of the new MPS.save and MPS.from_file methods.
  *_logging_enabled: boolean*
   Whether certain things are logged to Tensorboard/ to a Chrome timeline.
 
@@ -20,6 +20,6 @@ Properties
 *rate_of_change: float*
  The rate of change for the optimisation. Different values should be tried, as there is no 'right answer' that works for all situations, and depending on the data set, the same value can cause overshooting, or make the optimisation slower than it should be.
 *initial_weights: list*
- The initial weights for the network, if it is desired to override the default values from mps.prepare(self, data_source, iterations = 1000)
+ The initial weights for the network, if it is desired to override the default values from MPS.prepare. Deprecated in favour of the new MPS.save and MPS.from_file methods.
 *_logging_enabled: boolean*
  Whether certain things are logged to Tensorboard/ to a Chrome timeline.

--- a/trmps/FashionMNISTTraining.py
+++ b/trmps/FashionMNISTTraining.py
@@ -33,18 +33,19 @@ verbosity = -0
 
 cutoff = 100
 n_step = 6
+weights = None
 
 data_source = FashionMNISTDatasource(shrink=shrink, permuted=permuted, shuffled=shuffled)
+
+# Create network from scratch
 network = sqMPS(d_feature, d_output, input_size, special_node_loc)
 network.prepare(data_source=None, learning_rate=lin_reg_learning_rate,
                 iterations=lin_reg_iterations)
-# Load weights
-with open('weights', 'rb') as fp:
-    weights = pickle.load(fp)
-    if len(weights) != input_size:
-        weights = None
 
-# weights=None
+# Load network from saved configuration
+# network = MPS.from_file()
+
+# Training
 # optimizer_parameters = MPSOptimizerParameters(cutoff=cutoff, reg=reg, lr_reg=lr_reg,
 #                                               verbosity=verbosity, armijo_iterations=armijo_iterations)
 # training_parameters = MPSTrainingParameters(rate_of_change=rate_of_change, initial_weights=weights,
@@ -54,21 +55,4 @@ with open('weights', 'rb') as fp:
 #                 training_parameters)
 
 # Testing
-
-feed_dict = network.create_feed_dict(weights)
-test_features, test_labels = data_source.test_data
-features = tf.placeholder(tf.float32, shape=[input_size, None, d_feature])
-labels = tf.placeholder(tf.float32, shape=[None, d_output])
-f = network.predict(features)
-confusion_matrix = network.confusion_matrix(f, labels)
-accuracy = network.accuracy(f, labels)
-cost = network.cost(f, labels)
-feed_dict[features] = test_features
-feed_dict[labels] = test_labels
-with tf.Session() as sess:
-    sess.run(tf.global_variables_initializer())
-    conf, acc, test_f, test_cost = sess.run([confusion_matrix, accuracy, f, cost], feed_dict = feed_dict)
-print("\n\n\n\n Accuracy is:" + str(acc) + " and cost is:" + str(test_cost))
-print("\n\n\n\n" + str(conf))
-print("\n\n\n\n Sample prediction: " + str(test_f[1]))
-print("Correct prediction for this case is: " + str(test_labels[1]))
+network.test(data_source.test_data[0], data_source.test_data[1])

--- a/trmps/FashionMNISTTraining.py
+++ b/trmps/FashionMNISTTraining.py
@@ -15,12 +15,12 @@ shrink = False
 if shrink:
     input_size = 196
 
-special_node_loc = None
+special_node_loc = 14
 
 # Optimizer parameters
 batch_size = 20000
 max_size = 25
-min_singular_value = 0.001
+min_singular_value = 0.00
 reg = 0.01
 armijo_coeff = 10**(-4)
 armijo_iterations = 25
@@ -35,24 +35,40 @@ cutoff = 100
 n_step = 6
 
 data_source = FashionMNISTDatasource(shrink=shrink, permuted=permuted, shuffled=shuffled)
-
-# Initialise the model
-
-# with open('weights_sgd', 'rb') as fp:
-#     weights = pickle.load(fp)
-#     if len(weights) != input_size:
-#         weights = None
-
-weights=None
-optimizer_parameters = MPSOptimizerParameters(cutoff=cutoff, reg=reg, lr_reg=lr_reg,
-                                              verbosity=verbosity, armijo_iterations=armijo_iterations)
-training_parameters = MPSTrainingParameters(rate_of_change=rate_of_change, initial_weights=weights,
-                                            _logging_enabled=logging_enabled)
-
 network = sqMPS(d_feature, d_output, input_size, special_node_loc)
-network.prepare(data_source=data_source, learning_rate=lin_reg_learning_rate,
+network.prepare(data_source=None, learning_rate=lin_reg_learning_rate,
                 iterations=lin_reg_iterations)
-optimizer = SingleSiteMPSOptimizer(network, max_size, optimizer_parameters)
-optimizer.train(data_source, batch_size, n_step,
-                training_parameters)
+# Load weights
+with open('weights', 'rb') as fp:
+    weights = pickle.load(fp)
+    if len(weights) != input_size:
+        weights = None
 
+# weights=None
+# optimizer_parameters = MPSOptimizerParameters(cutoff=cutoff, reg=reg, lr_reg=lr_reg,
+#                                               verbosity=verbosity, armijo_iterations=armijo_iterations)
+# training_parameters = MPSTrainingParameters(rate_of_change=rate_of_change, initial_weights=weights,
+#                                             _logging_enabled=logging_enabled)
+# optimizer = SingleSiteMPSOptimizer(network, max_size, optimizer_parameters)
+# optimizer.train(data_source, batch_size, n_step,
+#                 training_parameters)
+
+# Testing
+
+feed_dict = network.create_feed_dict(weights)
+test_features, test_labels = data_source.test_data
+features = tf.placeholder(tf.float32, shape=[input_size, None, d_feature])
+labels = tf.placeholder(tf.float32, shape=[None, d_output])
+f = network.predict(features)
+confusion_matrix = network.confusion_matrix(f, labels)
+accuracy = network.accuracy(f, labels)
+cost = network.cost(f, labels)
+feed_dict[features] = test_features
+feed_dict[labels] = test_labels
+with tf.Session() as sess:
+    sess.run(tf.global_variables_initializer())
+    conf, acc, test_f, test_cost = sess.run([confusion_matrix, accuracy, f, cost], feed_dict = feed_dict)
+print("\n\n\n\n Accuracy is:" + str(acc) + " and cost is:" + str(test_cost))
+print("\n\n\n\n" + str(conf))
+print("\n\n\n\n Sample prediction: " + str(test_f[1]))
+print("Correct prediction for this case is: " + str(test_labels[1]))

--- a/trmps/MNISTTraining.py
+++ b/trmps/MNISTTraining.py
@@ -34,22 +34,23 @@ n_step = 6
 
 data_source = MNISTpreprocessing.MNISTDatasource(shrink=shrink, permuted=permuted, shuffled=shuffled)
 
-# Initialise the model
-
-# with open('weights_sgd', 'rb') as fp:
-#     weights = pickle.load(fp)
-#     if len(weights) != input_size:
-#         weights = None
-
 weights=None
+
 optimizer_parameters = MPSOptimizerParameters(cutoff=cutoff, reg=reg, lr_reg=lr_reg,
                                               verbosity=verbosity)
 training_parameters = MPSTrainingParameters(rate_of_change=rate_of_change, initial_weights=weights,
                                             _logging_enabled=logging_enabled)
-
+# Create network from scratch
 network = sqMPS(d_feature, d_output, input_size, special_node_loc)
 network.prepare(data_source=data_source, learning_rate=lin_reg_learning_rate)
+
+# Load network from saved configuration
+# network = MPS.from_file()
+
+# Training
 optimizer = MPSOptimizer(network, max_size, optimizer_parameters)
 optimizer.train(data_source, batch_size, n_step,
                 training_parameters)
 
+# Testing
+# network.test(data_source.test_data[0], data_source.test_data[1])

--- a/trmps/activityTraining.py
+++ b/trmps/activityTraining.py
@@ -14,7 +14,7 @@ permuted = False
 shuffled = False
 
 # Optimizer parameters
-max_size = 50
+max_size = 15
 batch_size = 2000
 rate_of_change = 10**(-7)
 lr_reg = 0.0
@@ -31,44 +31,23 @@ data_source = ap.activityDatasource(shuffled=shuffled)
 
 print(data_source.num_train_samples, data_source.num_test_samples)
 
-network = MPS(d_feature, d_output, input_size, special_node_loc=special_node_loc)
-network.prepare(data_source=data_source, iterations=lin_reg_iterations, learning_rate=lin_reg_learning_rate)
+# Create network from scratch
+# network = MPS(d_feature, d_output, input_size, special_node_loc=special_node_loc)
+# network.prepare(data_source=data_source, iterations=lin_reg_iterations, learning_rate=lin_reg_learning_rate)
 
-weights = None
+# Network from previous weights
+network = MPS.from_file()
 
-# Load weights
-# with open('weights', 'rb') as fp:
-#     weights = pickle.load(fp)
-#     if len(weights) != input_size:
-#         weights = None
+network.test(data_source.test_data[0], data_source.test_data[1])
 
 # Training
 
 optimizer_parameters = MPSOptimizerParameters(cutoff=cutoff, reg=reg, lr_reg=lr_reg, verbosity=verbosity,
                                               armijo_coeff=armijo_coeff)
-training_parameters = MPSTrainingParameters(rate_of_change=rate_of_change, initial_weights=weights,
+training_parameters = MPSTrainingParameters(rate_of_change=rate_of_change,
                                             _logging_enabled=logging_enabled)
 
 feature, label = data_source.next_training_data_batch(1000)
-# network.test(feature, label)
 optimizer = MPSOptimizer(network, max_size, optimizer_parameters)
 optimizer.train(data_source, batch_size, n_step,
                 training_parameters)
-
-# Testing
-
-# feed_dict = network.create_feed_dict(weights)
-# test_features, test_labels = data_source.test_data
-# features = tf.placeholder(tf.float32, shape=[input_size, None, d_feature])
-# labels = tf.placeholder(tf.float32, shape=[None, d_output])
-# f = network.predict(features)
-# confusion_matrix = network.confusion_matrix(f, labels)
-# accuracy = network.accuracy(f, labels)
-# feed_dict[features] = test_features
-# feed_dict[labels] = test_labels
-# with tf.Session() as sess:
-#     sess.run(tf.global_variables_initializer())
-#     conf, acc, test_f = sess.run([confusion_matrix, accuracy, f], feed_dict = feed_dict)
-# print("\n\n\n\n Accuracy is:" + str(acc))
-# print("\n\n\n\n" + str(conf))
-# print("\n\n\n\n Sample prediction: " + str(test_f[0]))

--- a/trmps/baseoptimizer.py
+++ b/trmps/baseoptimizer.py
@@ -23,6 +23,7 @@ class BaseOptimizer(object):
             See documentation for MPSOptimizerParameters for more detail.
         """
         self.parameters = optional_parameters
+        self.path = self.parameters.path
         self.MPS = MPSNetwork
         self.use_hessian = self.parameters.use_hessian
         if self.use_hessian and type(self.MPS) is sqMPS:
@@ -123,8 +124,7 @@ class BaseOptimizer(object):
                     with open("timeline.json", "w") as f:
                         f.write(ctf)
                     run_metadata = tf.RunMetadata()
-                with open('weights', 'wb') as fp:
-                    pickle.dump(self.test, fp)
+                self.MPS.save(self.test, path=self.path)
                 end = time.time()
                 print(time.strftime("%Y-%m-%d %H:%M:%S"))
                 print('step {}, training cost {}, accuracy {}. Took {} s'.format(i, train_c, train_acc, end - start))

--- a/trmps/cardioTraining.py
+++ b/trmps/cardioTraining.py
@@ -36,49 +36,18 @@ print(data_source.num_train_samples, data_source.num_test_samples)
 weights = None
 
 # DMRG optimizer
-
-with open('weights_sgd', 'rb') as fp:
-    weights = pickle.load(fp)
-    if len(weights) != input_size:
-        weights = None
-training_parameters.initial_weights = weights
-
+# Create network from scratch
 network = sqMPS(d_feature, d_output, input_size,
                 special_node_loc=special_node_loc)
 network.prepare(data_source, lin_reg_iterations)
+
+# Load network from saved configuration
+# network = MPS.from_file()
+
 optimizer = MPSOptimizer(network, max_size, optimizer_parameters)
 optimizer.train(data_source, batch_size, n_step,
                 training_parameters)
 
-# SGD optimizer
-
-# batch_size = int(data_source.num_train_samples / 10)
-# network = SimpleMPS(d_feature, d_output, input_size,
-#                     special_node_loc=special_node_loc, reg=reg)
-# network.prepare(data_source, lin_reg_iterations)
-# optimizer = SGDOptimizer(network)
-# optimizer.train(data_source, batch_size, n_step,
-#                 rate_of_change=rate_of_change)
-
 # Testing
+# network.test(data_source.test_data[0], data_source.test_data[1])
 
-# with open('weights', 'rb') as fp:
-#    weights = pickle.load(fp)
-#    if len(weights) != input_size:
-#        weights = None
-#
-# network.prepare(data_source)
-# feed_dict = network.create_feed_dict(weights)
-# test_features, test_labels = data_source.test_data
-# features = tf.placeholder(tf.float32, shape=[input_size, None, d_feature])
-# labels = tf.placeholder(tf.float32, shape=[None, d_output])
-# f = network.predict(features)
-# confusion_matrix = network.confusion_matrix(f, labels)
-# accuracy = network.accuracy(f, labels)
-# feed_dict[features] = test_features
-# feed_dict[labels] = test_labels
-# with tf.Session() as sess:
-#     sess.run(tf.global_variables_initializer())
-#     conf, acc = sess.run([confusion_matrix, accuracy], feed_dict = feed_dict)
-# print("\n\n\n\n Accuracy is:" + str(acc))
-# print("\n\n\n\n" + str(conf))

--- a/trmps/parameterObjects.py
+++ b/trmps/parameterObjects.py
@@ -61,7 +61,8 @@ class MPSTrainingParameters(object):
             overshooting, or make the optimisation slower than it should be.
         :param initial_weights: list
             The initial weights for the network, if it is desired to override the default values
-            from mps.prepare(self, data_source, iterations = 1000)
+            from mps.prepare(self, data_source, iterations = 1000).
+            Deprecated.
         :param _logging_enabled: boolean
             Whether certain things are logged to Tensorboard/ to a Chrome timeline.
         """

--- a/trmps/parameterObjects.py
+++ b/trmps/parameterObjects.py
@@ -6,7 +6,7 @@ class MPSOptimizerParameters(object):
     def __init__(self, cutoff=1000,
                  reg=0.001, lr_reg=0.99, min_singular_value=10**(-4),
                  verbosity=0, armijo_coeff=10**(-4), use_hessian=False,
-                 armijo_iterations=10):
+                 armijo_iterations=10, path="MPSconfig"):
         """
         :param cutoff: float
             The cutoff value for the gradient. Anything above this is clipped off.
@@ -45,6 +45,7 @@ class MPSOptimizerParameters(object):
         self.armijo_coeff = armijo_coeff
         self.use_hessian = use_hessian
         self.armijo_iterations = armijo_iterations
+        self.path = path
 
 class MPSTrainingParameters(object):
     """


### PR DESCRIPTION
Previous to this file format, the weights were saved as a pickled list. The disadvantages of this were that
* The list didn't explicitly contain higher level data about the MPS, e.g. the input_size
    - This meant that to initialise an MPS, even if we had the weights, we had to initialise MPSs by feeding in all of the parameters manually
* Pickle files are Python-specific
This file format was created to address these issues. An added benefit of the file format is that it is much [more space efficient than a Pickle](https://stackoverflow.com/questions/9619199/best-way-to-preserve-numpy-arrays-on-disk). By using this file format, one can also save the configuration of an MPS without saving the weights.